### PR TITLE
Options page & Popup UI

### DIFF
--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -1,4 +1,13 @@
 import { createStorage, StorageType, type BaseStorage, SessionAccessLevel } from './base';
 import { exampleThemeStorage } from './exampleThemeStorage';
-
-export { exampleThemeStorage, createStorage, StorageType, SessionAccessLevel, BaseStorage };
+import { savedGoalsStorage } from './savedGoalsStorage';
+import { savedSettingsStorage } from './savedSettingsStorage';
+export {
+    exampleThemeStorage,
+    savedGoalsStorage,
+    savedSettingsStorage,
+    createStorage,
+    StorageType,
+    SessionAccessLevel,
+    BaseStorage,
+};

--- a/packages/storage/lib/savedGoalsStorage.ts
+++ b/packages/storage/lib/savedGoalsStorage.ts
@@ -1,0 +1,17 @@
+import { BaseStorage, createStorage, StorageType } from './base';
+
+type UserGoals = {
+    helpful: string;
+    harmful: string;
+};
+
+type GoalsStorage = BaseStorage<UserGoals>;
+
+const defaultGoals: UserGoals = { helpful: '', harmful: '' };
+
+const goalsStorage = createStorage<UserGoals>('user-goals-storage-key', defaultGoals, {
+    storageType: StorageType.Local,
+    liveUpdate: true,
+});
+
+export const savedGoalsStorage: GoalsStorage = goalsStorage;

--- a/packages/storage/lib/savedSettingsStorage.ts
+++ b/packages/storage/lib/savedSettingsStorage.ts
@@ -1,0 +1,17 @@
+import { BaseStorage, createStorage, StorageType } from './base';
+
+type UserSettings = {
+    openAIApiKey: string;
+    blockerEnabled: boolean;
+};
+
+type SettingsStorage = BaseStorage<UserSettings>;
+
+const defaultSettings: UserSettings = { openAIApiKey: '', blockerEnabled: false };
+
+const settingsStorage = createStorage<UserSettings>('user-settings-storage-key', defaultSettings, {
+    storageType: StorageType.Local,
+    liveUpdate: true,
+});
+
+export const savedSettingsStorage: SettingsStorage = settingsStorage;

--- a/pages/options/src/GoalsTab.tsx
+++ b/pages/options/src/GoalsTab.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useStorageSuspense, withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
+import { savedGoalsStorage } from '@chrome-extension-boilerplate/storage';
+
+const GoalsTab = () => {
+  const { helpful, harmful } = useStorageSuspense(savedGoalsStorage);
+  const [helpfulVideos, setHelpfulVideos] = useState(helpful);
+  const [harmfulVideos, setHarmfulVideos] = useState(harmful);
+  const [showSavedMessage, setShowSavedMessage] = useState(false);
+
+  const initialGoals = useRef({ helpful, harmful });
+
+  useEffect(() => {
+    // Update the ref when the component mounts
+    initialGoals.current = { helpful, harmful };
+  }, [helpful, harmful]);
+
+  const saveGoals = async () => {
+    await savedGoalsStorage.set({ helpful: helpfulVideos, harmful: harmfulVideos });
+    initialGoals.current = { helpful: helpfulVideos, harmful: harmfulVideos };
+    setShowSavedMessage(true);
+    setTimeout(() => setShowSavedMessage(false), 3000);
+  };
+
+  const hasChanges = () => {
+    return helpfulVideos !== initialGoals.current.helpful || harmfulVideos !== initialGoals.current.harmful;
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-8">Goals</h1>
+      <div className="mb-4">
+        <label htmlFor="helpful-videos" className="block text-sm font-medium text-gray-700">
+          Watch Helpful Videos:
+        </label>
+        <textarea
+          id="helpful-videos"
+          className="mt-1 p-2 block w-96 border-2 rounded-md border-gray-300 shadow-sm resize-none
+              focus:border-gray-700 focus:outline-none"
+          value={helpfulVideos}
+          onChange={e => setHelpfulVideos(e.target.value)}
+          rows={5}
+        />
+      </div>
+      <div className="mb-4">
+        <label htmlFor="harmful-videos" className="block text-sm font-medium text-gray-700">
+          Avoid Harmful Videos:
+        </label>
+        <textarea
+          id="harmful-videos"
+          className="mt-1 p-2 block w-96 border-2 rounded-md border-gray-300 shadow-sm resize-none
+              focus:border-gray-700 focus:outline-none"
+          value={harmfulVideos}
+          onChange={e => setHarmfulVideos(e.target.value)}
+          rows={5}
+        />
+      </div>
+      {hasChanges() && (
+        <button
+          className="block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          onClick={saveGoals}>
+          Save Goals
+        </button>
+      )}
+      {showSavedMessage && <div className="mt-4 py-2 px-4 text-sm text-green-500">Saved!</div>}
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(GoalsTab, <div>Loading...</div>), <div>Error Occurred</div>);

--- a/pages/options/src/InfoTab.tsx
+++ b/pages/options/src/InfoTab.tsx
@@ -1,0 +1,38 @@
+import { withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
+
+const InfoTab = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-8">Extension Information</h1>
+      <p className="mt-2 text-gray-600">
+        This extension aims to enhance your digital experience by providing features that help manage and filter your
+        digital content. Whether you’re looking to block distractions, organize your tasks, or secure your online
+        environment, this tool is designed to assist you efficiently and effectively.
+      </p>
+
+      <h2 className="mt-4 text-lg font-semibold text-gray-800">Key Features</h2>
+      <ul className="list-disc list-inside text-gray-600">
+        <li>
+          <strong>AI Content Filtering:</strong> Automatically filters out non-essential content based on your
+          preferences.
+        </li>
+        <li>
+          <strong>Goal Setting:</strong> Allows you to set specific objectives and track your progress towards these
+          goals.
+        </li>
+        <li>
+          <strong>Privacy Enhancements:</strong> Provides additional layers of privacy to secure your online activities.
+        </li>
+      </ul>
+
+      <h2 className="mt-4 text-lg font-semibold text-gray-800">How to Use</h2>
+      <p className="text-gray-600">
+        To start using the extension, navigate to the settings tab and enter your preferences and API key if necessary.
+        Set your goals in the goals tab to begin tracking your progress. You can toggle AI features on and off according
+        to your needs.
+      </p>
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(InfoTab, <div>Loading...</div>), <div>Error Occurred</div>);

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -1,52 +1,53 @@
 import '@src/Options.css';
-import { useStorageSuspense, withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
-import { exampleThemeStorage, createStorage } from '@chrome-extension-boilerplate/storage';
-import React, { useState, useEffect } from 'react';
-
-const helpfulVideosStorage = createStorage('helpfulVideos', '');
-const harmfulVideosStorage = createStorage('harmfulVideos', '');
+import { withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
+import InfoTab from './InfoTab';
+import GoalsTab from './GoalsTab';
+import SettingsTab from './SettingsTab';
+import React, { useState } from 'react';
 
 const Options = () => {
-  const theme = useStorageSuspense(exampleThemeStorage);
-  const [helpfulVideos, setHelpfulVideos] = useState('');
-  const [harmfulVideos, setHarmfulVideos] = useState('');
+  const [activeTab, setActiveTab] = useState<string>('settings');
 
-  useEffect(() => {
-    const loadInitialValues = async () => {
-      const initialHelpfulVideos = await helpfulVideosStorage.get();
-      const initialHarmfulVideos = await harmfulVideosStorage.get();
-      setHelpfulVideos(initialHelpfulVideos);
-      setHarmfulVideos(initialHarmfulVideos);
-    };
-    loadInitialValues();
-  }, []);
-
-  const handleSave = async () => {
-    try {
-      await helpfulVideosStorage.set(helpfulVideos);
-      await harmfulVideosStorage.set(harmfulVideos);
-    } catch (error) {
-      console.error('Error saving input values to storage:', error);
+  const renderTab = () => {
+    switch (activeTab) {
+      case 'info':
+        return <InfoTab />;
+      case 'goals':
+        return <GoalsTab />;
+      case 'settings':
+        return <SettingsTab />;
+      default:
+        return <InfoTab />;
     }
   };
 
   return (
-    <div
-      className="App-container"
-      style={{
-        backgroundColor: theme === 'light' ? '#eee' : '#222',
-      }}>
-      <img src={chrome.runtime.getURL('options/logo.svg')} className="App-logo" alt="logo" />
-      <span style={{ color: theme === 'light' ? '#0281dc' : undefined, marginBottom: '10px' }}>Options</span>
-      <div>
-        <label htmlFor="helpful-videos">Helpful Videos:</label>
-        <textarea id="helpful-videos" value={helpfulVideos} onChange={e => setHelpfulVideos(e.target.value)} />
+    <div className="flex flex-col h-screen bg-gray-100">
+      <div className="text-xl font-bold p-4 shadow">YouTube Addiction Rehab</div>
+
+      <div className="flex flex-1 overflow-hidden">
+        <div className="w-64 bg-white shadow-md">
+          <div className="flex flex-col">
+            <button
+              className={`p-4 text-left ${activeTab === 'info' ? 'bg-blue-500 text-white' : 'hover:bg-blue-100'} transition duration-150 ease-in-out`}
+              onClick={() => setActiveTab('info')}>
+              Info
+            </button>
+            <button
+              className={`p-4 text-left ${activeTab === 'goals' ? 'bg-blue-500 text-white' : 'hover:bg-blue-100'} transition duration-150 ease-in-out`}
+              onClick={() => setActiveTab('goals')}>
+              Goals
+            </button>
+            <button
+              className={`p-4 text-left ${activeTab === 'settings' ? 'bg-blue-500 text-white' : 'hover:bg-blue-100'} transition duration-150 ease-in-out`}
+              onClick={() => setActiveTab('settings')}>
+              Settings
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 bg-white p-4 overflow-auto">{renderTab()}</div>
       </div>
-      <div>
-        <label htmlFor="harmful-videos">Harmful Videos:</label>
-        <textarea id="harmful-videos" value={harmfulVideos} onChange={e => setHarmfulVideos(e.target.value)} />
-      </div>
-      <button onClick={handleSave}>Save</button>
     </div>
   );
 };

--- a/pages/options/src/SettingsTab.tsx
+++ b/pages/options/src/SettingsTab.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useStorageSuspense, withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
+import { savedSettingsStorage } from '@chrome-extension-boilerplate/storage';
+
+const SettingsTab = () => {
+  const { openAIApiKey, blockerEnabled } = useStorageSuspense(savedSettingsStorage);
+  const [apiKey, setApiKey] = useState<string>(openAIApiKey);
+  const [aiBlockerEnabled, setAiBlockerEnabled] = useState<boolean>(blockerEnabled);
+  const [showSavedMessage, setShowSavedMessage] = useState(false);
+
+  // Ref to store the initial values for comparison
+  const initialSettings = useRef({ openAIApiKey, blockerEnabled });
+
+  useEffect(() => {
+    // Update the ref when the component mounts
+    initialSettings.current = { openAIApiKey, blockerEnabled };
+  }, [openAIApiKey, blockerEnabled]);
+
+  const saveSettings = async () => {
+    await savedSettingsStorage.set({ openAIApiKey: apiKey, blockerEnabled: aiBlockerEnabled });
+    // Update initial settings after save
+    initialSettings.current = { openAIApiKey: apiKey, blockerEnabled: aiBlockerEnabled };
+    setShowSavedMessage(true);
+    setTimeout(() => setShowSavedMessage(false), 3000);
+  };
+
+  // Function to determine if the current state differs from the initial state
+  const hasChanges = () => {
+    return (
+      apiKey !== initialSettings.current.openAIApiKey || aiBlockerEnabled !== initialSettings.current.blockerEnabled
+    );
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-3xl font-bold mb-8">Settings</h1>
+      <div className="mb-4">
+        <label htmlFor="api-key" className="block text-sm font-medium text-gray-700">
+          API Key
+        </label>
+        <input
+          id="api-key"
+          type="password"
+          className="mt-1 p-2 block w-96 border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+        />
+      </div>
+      <div className="mb-4">
+        <label htmlFor="ai-blocker" className="flex items-center space-x-2">
+          <input
+            id="ai-blocker"
+            type="checkbox"
+            className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-offset-0 focus:ring-blue-200 focus:ring-opacity-50"
+            checked={aiBlockerEnabled}
+            onChange={() => setAiBlockerEnabled(!aiBlockerEnabled)}
+          />
+          <span>Enable AI Blocker</span>
+        </label>
+      </div>
+      {hasChanges() && (
+        <button
+          className="block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          onClick={saveSettings}>
+          Save Settings
+        </button>
+      )}
+      {showSavedMessage && <div className="py-2 px-4 text-sm text-green-500">Saved!</div>}
+    </div>
+  );
+};
+
+export default withErrorBoundary(withSuspense(SettingsTab, <div>Loading...</div>), <div>Error Occurred</div>);

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -1,11 +1,15 @@
 import '@src/Popup.css';
 import { useStorageSuspense, withErrorBoundary, withSuspense } from '@chrome-extension-boilerplate/shared';
-import { exampleThemeStorage } from '@chrome-extension-boilerplate/storage';
+import { exampleThemeStorage, } from '@chrome-extension-boilerplate/storage';
 
 import { ComponentPropsWithoutRef } from 'react';
 
 const Popup = () => {
   const theme = useStorageSuspense(exampleThemeStorage);
+
+  const openOptionsPage = () => {
+    chrome.runtime.openOptionsPage(); // This opens the options page.
+  };
 
   return (
     <div
@@ -28,6 +32,7 @@ const Popup = () => {
           Learn React!
         </a>
         <ToggleButton>Toggle theme</ToggleButton>
+        <button className="options-button mt-4" onClick={openOptionsPage}>Open Options</button>
       </header>
     </div>
   );


### PR DESCRIPTION
Options page with three tabs
1. Info
2. Goals
3. Settings

Saving data to extension storage

Popup with goals editor same as options page

### Note

Had some issue using component between options and popup (`GoalEditor`), Tailwind style won't load once a component is imported and used. 