### PR TITLE
Fix return to home bug

### DIFF
--- a/chrome-extension/lib/background/index.ts
+++ b/chrome-extension/lib/background/index.ts
@@ -40,7 +40,7 @@ async function analyzeRecommendations(videoData: Record<string, string>) {
         Evaluate each video and determine if it should be shown to the user or not.
         Make sure you evaluate the video based on all of the user's goals. Any unrelated video shown can be a negative distraction.
         Return a JSON object where each key is the video ID and the value is a short sentence explaining why the video should be shown.
-        Only include videos that should be shown in the response.
+        Only include videos that should be shown (which means related to the user's goals) in the response JSON.
         response must be pure JSON without any other text, and it needs to be valid JSON`;
 
     const prompt = `Given the user's goal: "${helpful}", and videos to avoid: "${harmful}", evaluate the following video data: ${JSON.stringify(videoData)}.

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -303,6 +303,11 @@ async function analyzeRecommendation() {
     }
   });
 
+
+  document.addEventListener('yt-navigate-start', () => {
+    observer.disconnect();
+  });
+
   if (secondaryElement) {
     observer.observe(secondaryElement, {
       childList: true,
@@ -367,6 +372,10 @@ async function analyzeHome(filterEnabled: boolean) {
 
     });
 
+
+    document.addEventListener('yt-navigate-start', () => {
+      observer.disconnect();
+    });
 
     if (primaryElement) {
       observer.observe(primaryElement, {


### PR DESCRIPTION
Sometimes clicking the top left youtube logo going back to home, will still show previous filtered result (position). Make sure we disconnect the observers so it won't be carried around. 