### PR TITLE
Add local model settings

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -18,7 +18,7 @@ const manifest = Object.assign({
   version: packageJson.version,
   description: '__MSG_extensionDescription__',
   permissions: ['storage', 'tabs'],
-  host_permissions: ['https://api.anthropic.com/*'],
+  host_permissions: ['https://api.anthropic.com/*', 'http://localhost*'],
   options_page: 'options/index.html',
   background: {
     service_worker: 'background.iife.js',

--- a/packages/storage/lib/savedSettingsStorage.ts
+++ b/packages/storage/lib/savedSettingsStorage.ts
@@ -9,7 +9,9 @@ type UserSettings = {
     filterEnabled: boolean;
     hideShortsEnabled: boolean;
     llmModel: string;
-    aiProvider: 'openai' | 'anthropic' | 'groq';
+    aiProvider: 'openai' | 'anthropic' | 'groq' | 'local';
+    localModelEndpoint: string;
+    localModelName: string;
     apiErrorStatus: {
         type: 'AUTH' | 'RATE_LIMIT' | null;
         timestamp: number | null;
@@ -28,6 +30,8 @@ const defaultSettings: UserSettings = {
     hideShortsEnabled: false,
     llmModel: 'gpt-4o-mini',
     aiProvider: 'openai',
+    localModelEndpoint: '',
+    localModelName: '',
     apiErrorStatus: {
         type: null,
         timestamp: null,

--- a/pages/options/src/SettingsTab.tsx
+++ b/pages/options/src/SettingsTab.tsx
@@ -11,7 +11,9 @@ type UserSettings = {
   filterEnabled: boolean;
   hideShortsEnabled: boolean;
   llmModel: string;
-  aiProvider: 'openai' | 'anthropic' | 'groq';
+  aiProvider: 'openai' | 'anthropic' | 'groq' | 'local';
+  localModelEndpoint: string;
+  localModelName: string;
 };
 
 interface ToggleSwitchProps {
@@ -45,6 +47,26 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ id, checked, onChange, labe
         {checked && children && <div className='max-w-[300px]'>{children}</div>}
       </div>
     </label>
+  </div>
+);
+
+const TabSelector: React.FC<{
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}> = ({ activeTab, setActiveTab }) => (
+  <div className="flex mb-4">
+    <button
+      className={`py-2 px-4 ${activeTab === 'hosted' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700'} rounded-l-md`}
+      onClick={() => setActiveTab('hosted')}
+    >
+      Hosted Providers
+    </button>
+    <button
+      className={`py-2 px-4 ${activeTab === 'local' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700'} rounded-r-md`}
+      onClick={() => setActiveTab('local')}
+    >
+      Local Model
+    </button>
   </div>
 );
 
@@ -86,56 +108,16 @@ const SettingsTab = () => {
     }
   };
 
+  const [activeTab, setActiveTab] = useState('hosted');
+
   return (
     <div className="p-4">
       <h1 className="text-3xl font-bold mb-8">Settings</h1>
       <div className='flex flex-row'>
         <div className='mr-16'>
-          <h2 className="text-2xl font-bold mb-4">AI Settings</h2>
-          <div className="mb-4">
-            <label htmlFor="api-key" className="block text-sm font-medium text-white">
-              OpenAI API Key
-            </label>
-            <input
-              id="oepn-api-key"
-              type="password"
-              className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
-              value={settings.openAIApiKey}
-              onChange={e => handleChange('openAIApiKey', e.target.value)}
-            />
-            <div className='text-gray-500'>API keys will only be stored on your device.</div>
-          </div>
+          <h2 className="text-2xl font-bold mb-4">LLM Model Settings</h2>
 
-          <div className='mb-4'>
-            <label htmlFor="anthropic-api-key" className="block text-sm font-medium text-white">
-              Anthropic API Key
-            </label>
-            <input
-              id="anthropic-api-key"
-              type="password"
-              className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
-              value={settings.anthropicApiKey}
-              onChange={e => handleChange('anthropicApiKey', e.target.value)}
-            />
-            <div className='text-gray-500'>API keys will only be stored on your device.</div>
-          </div>
-
-
-          <div className="mb-4">
-            <label htmlFor="api-key" className="block text-sm font-medium text-white">
-              Groq API Key
-            </label>
-            <input
-              id="oepn-api-key"
-              type="password"
-              className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
-              value={settings.groqApiKey}
-              onChange={e => handleChange('groqApiKey', e.target.value)}
-            />
-            <div className='text-gray-500'>API keys will only be stored on your device.</div>
-          </div>
-
-          <div className='mb-4'>
+          <div className='mb-4 border-t border-gray-600 pt-4'>
             <label htmlFor="model-select" className="block text-sm font-medium text-white">
               Choose a model:
             </label>
@@ -153,6 +135,8 @@ const SettingsTab = () => {
                   handleChange('aiProvider', 'anthropic');
                 } else if (selectedModel.startsWith('llama')) {
                   handleChange('aiProvider', 'groq');
+                } else if (selectedModel === 'local') {
+                  handleChange('aiProvider', 'local');
                 }
               }}>
               {settings.openAIApiKey && (
@@ -175,17 +159,113 @@ const SettingsTab = () => {
                   <option value="llama-3.1-70b-versatile">Llama 3.1 70B</option>
                 </>
               )}
+              {settings.localModelEndpoint && settings.localModelName && (
+                <option value="local">Local Model ({settings.localModelName})</option>
+              )}
             </select>
+            <div className='text-gray-500'>Availble models will show after entering settings below</div>
           </div>
+          <TabSelector activeTab={activeTab} setActiveTab={setActiveTab} />
 
-          <div className='flex flex-row items-center mb-4 p-2 w-128 border border-gray-600 rounded-md w-96'>
-            <div className='mr-2'>⚡</div>
-            <p className='text-sm text-gray-300'>
-              <strong>Recommend starting with smaller models such as Claude 3 Haiku, GPT-4o mini, LLaMA 3.1 70B.</strong>
-              <br />They are cheap and fast, with good enough results.
-              <br />If you want super low latency, go with Groq LLaMA 3.1 70B.
-            </p>
-          </div>
+          {activeTab === 'hosted' && (
+            <>
+              <div className="mb-4">
+                <label htmlFor="open-api-key" className="block text-sm font-medium text-white">
+                  OpenAI API Key
+                </label>
+                <input
+                  id="open-api-key"
+                  type="password"
+                  className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+                  value={settings.openAIApiKey}
+                  onChange={e => handleChange('openAIApiKey', e.target.value)}
+                />
+                <div className='text-gray-500'>API keys will only be stored on your device.</div>
+              </div>
+
+              <div className='mb-4'>
+                <label htmlFor="anthropic-api-key" className="block text-sm font-medium text-white">
+                  Anthropic API Key
+                </label>
+                <input
+                  id="anthropic-api-key"
+                  type="password"
+                  className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+                  value={settings.anthropicApiKey}
+                  onChange={e => handleChange('anthropicApiKey', e.target.value)}
+                />
+                <div className='text-gray-500'>API keys will only be stored on your device.</div>
+              </div>
+
+              <div className="mb-4">
+                <label htmlFor="api-key" className="block text-sm font-medium text-white">
+                  Groq API Key
+                </label>
+                <input
+                  id="oepn-api-key"
+                  type="password"
+                  className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+                  value={settings.groqApiKey}
+                  onChange={e => handleChange('groqApiKey', e.target.value)}
+                />
+                <div className='text-gray-500'>API keys will only be stored on your device.</div>
+              </div>
+
+
+              <div className='flex flex-row items-center mb-4 p-2 w-128 border border-gray-600 rounded-md w-96'>
+                <div className='mr-2'>⚡</div>
+                <p className='text-sm text-gray-300'>
+                  <strong>Recommend starting with smaller models such as Claude 3 Haiku, GPT-4o mini, LLaMA 3.1 70B.</strong>
+                  <br />They are cheap and fast, with good enough results.
+                  <br />If you want super low latency, go with Groq LLaMA 3.1 70B.
+                </p>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'local' && (
+            <>
+              <div className="mb-4">
+                <label htmlFor="local-model-port" className="block text-sm font-medium text-white">
+                  Local Model endpoint
+                </label>
+                <input
+                  id="local-model-endpoint"
+                  type="text"
+                  placeholder="http://localhost:11434/api/chat (ollama)"
+                  className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+                  value={settings.localModelEndpoint}
+                  onChange={e => handleChange('localModelEndpoint', e.target.value)}
+                />
+                <div className='text-gray-500'>Endpoint for the local model server.</div>
+              </div>
+
+              <div className="mb-4">
+                <label htmlFor="local-model-name" className="block text-sm font-medium text-white">
+                  Local Model Name
+                </label>
+                <input
+                  id="local-model-name"
+                  type="text"
+                  className="mt-1 p-2 block w-96 text-black border-2 rounded-md border-gray-300 shadow-sm focus:border-gray-700 focus:outline-none"
+                  value={settings.localModelName}
+                  onChange={e => handleChange('localModelName', e.target.value)}
+                />
+                <div className='text-gray-500'>Name of the local model server.</div>
+              </div>
+
+              <div className='flex flex-row items-center mb-4 p-2 w-128 border border-gray-600 rounded-md w-96'>
+                <div className='mr-2'>⚡</div>
+                <p className='text-sm text-gray-300'>
+                  <strong>For using Ollama, you need to setup CORS in the Ollama server.</strong>
+                  <br /> you can run the following command in the terminal to allow all origins:
+                  <p className='bg-gray-600 p-2 rounded-md my-1'>launchctl setenv OLLAMA_ORIGINS "*"</p>
+                </p>
+              </div>
+            </>
+          )}
+
+
         </div>
 
         <div>


### PR DESCRIPTION
### Main changes
- Change "AI settings" to "LLM Model settings"
- Move model selection to the top
- Tab select "hosted providers" and "local model"
<img width="200" alt="Screenshot 2024-08-27 at 11 03 26 PM" src="https://github.com/user-attachments/assets/aa8917bc-5257-426b-b201-3dcaf0d63ecc">
<img width="200" alt="Screenshot 2024-08-27 at 11 03 21 PM" src="https://github.com/user-attachments/assets/51de8cc9-6083-4352-85c4-8068e592219a">

### Example usage 
Endpoint: `http://localhost:11434/api/chat`
Model name: `llama3.1:8b`

Tested ollama with my M3 Max Macbook pro. It takes 10-20 seconds to analyze the home page with llama3.1:8b, and the result is not very good. From my experience, since youtube titles are a bit more vague, a 70b model can handle evaluation better. If you have good hardware maybe it's doable without using a paid provider.

For ollama, CORS settings is needed
running `launchctl setenv OLLAMA_ORIGINS "*"` will make it work ([source](https://medium.com/dcoderai/how-to-handle-cors-settings-in-ollama-a-comprehensive-guide-ee2a5a1beef0))